### PR TITLE
Minor shortcuts in main.hs.

### DIFF
--- a/src/main.hs
+++ b/src/main.hs
@@ -1,3 +1,4 @@
+import Control.Monad (replicateM)
 import NestedSampling.RNG
 import NestedSampling.SpikeSlab
 
@@ -9,15 +10,12 @@ main = do
     putStrLn "# Generating 10 particles from the prior\
                        \ and printing their log likelihoods"
 
-    -- List of IO actions which generate particles from the prior
-    let actions = [fromPrior | i <- [0..9]] :: [IO [Double]]
+    -- Generate particles from the prior
+    particles <- replicateM 10 fromPrior
 
-    -- Execute the actions
-    particles <- sequence actions
+    -- Apply logLikelihood to each particle
+    let lls = map logLikelihood particles
 
-    -- Get the log likelihoods and turn them into strings
-    let s = (map show $ map logLikelihood particles) :: [String]
-
-    -- Print them
-    putStrLn $ foldl (++) "" $ map (++ "\n") s
+    -- Print the results
+    mapM_ print lls
 


### PR DESCRIPTION
Everything you've written is perfectly sound - here I've just simplified a couple of things using some common patterns.

* Using a list comprehension to create actions to run later works great.  An optimization, given we're running one action multiple times, is to use `replicateM`, which lives in `Control.Monad`.  This will directly run the action the specified number of times.
* You can avoid manual rendering and string-building/munging here by applying `logLikelihood` to every particle and then executing the `print` action over everything in the resulting list.  To run an action over every element of a list you can use `mapM_`, which is in the Prelude.  `print` will also automatically add a newline.

A couple of other tips re: the original code:

*Usually* if you're building actions to later run with `sequence` there's a one-stop shop available somewhere that can do everything at once.  `replicateM` and `mapM` are good examples.  There are also variants like `replicateM_` and `mapM_` with the trailing underscore that *discard their results*, which is useful when you just want to run the action and don't care what it returns (such as when printing).

You can always simplify multiple maps by composing the mapping functions together.  So:

```
map show $ map logLikelihood particles
```

becomes

```
map (show . logLikelihood) particles
```

This way you only traverse the list once.  GHC tends to optimize for this kind of thing anyway, but nonetheless.

Also: `foldl` is one of those dumb legacy Prelude things that almost solely exists to trap beginners.  It should almost never be used as it leaks space unnecessarily, building up thunks in memory as it traverses a list.  A better alternative is `foldl'`, which traverses a list strictly  and lives in `Data.List`.  (`foldr` is ok and doesn't have the same weird properties as `foldl`)