### PR TITLE
Make fields of Sampler strict.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.hi
 *.o
 main
-
+*swp
+.stack-work

--- a/src/NestedSampling/Sampler.hs
+++ b/src/NestedSampling/Sampler.hs
@@ -10,11 +10,11 @@ import NestedSampling.RNG
 -- A sampler
 data Sampler = Sampler
                {
-                   numParticles :: Int,
-                   mcmcSteps :: Int,
-                   theParticles :: [(V.Vector Double)],
-                   theLogLikelihoods :: [Double],
-                   iteration :: Int
+                   numParticles      :: {-# UNPACK #-} !Int,
+                   mcmcSteps         :: {-# UNPACK #-} !Int,
+                   theParticles      :: ![V.Vector Double],
+                   theLogLikelihoods :: ![Double],
+                   iteration         :: {-# UNPACK #-}!Int
                } deriving Show
 
 -- Choose a particle to copy, that isn't number k


### PR DESCRIPTION
Using strict fields is usually one of the most reliable ways to get
large performance boosts.  On primitive types like Int and Double you
can use the {-# UNPACK #-} pragma to make sure that the value is unboxed
as well.