### PR TITLE
Use a priority search queue to store particles (weighted by log-likelihood).

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ main
 sample.txt
 sample_info.txt
 tags
-
+*prof

--- a/NestedSampling-hs.cabal
+++ b/NestedSampling-hs.cabal
@@ -1,5 +1,5 @@
 name:                NestedSampling-hs
-version:             0.1.1
+version:             0.1.2
 synopsis:            Classic Nested Sampling.
 license:             MIT
 license-file:        LICENSE
@@ -25,6 +25,7 @@ library
       base >= 4 && < 6
     , mwc-random
     , primitive
+    , psqueues
     , vector
 
 executable ns-example
@@ -37,3 +38,15 @@ executable ns-example
       base
     , NestedSampling-hs
     , mwc-random
+
+executable ns-mini-example
+  hs-source-dirs:    src
+  Main-is:           Mini.hs
+  default-language:  Haskell2010
+  ghc-options:
+    -O2 -fprof-auto -rtsopts
+  build-depends:
+      base
+    , NestedSampling-hs
+    , mwc-random
+

--- a/lib/NestedSampling/Sampler.hs
+++ b/lib/NestedSampling/Sampler.hs
@@ -1,14 +1,14 @@
-{-# LANGUAGE BangPatterns #-}
+{-# OPTIONS_GHC -fno-warn-type-defaults #-}
 
 module NestedSampling.Sampler where
 
 import System.IO
+import Control.Monad
 import Control.Monad.Primitive (RealWorld)
 import Data.List
-import qualified Data.Vector as V
-import qualified Data.Vector.Mutable as VM
+import Data.IntPSQ (IntPSQ)
+import qualified Data.IntPSQ as PSQ
 import qualified Data.Vector.Unboxed as U
-import qualified Data.Vector.Unboxed.Mutable as UM
 import System.Random.MWC (Gen)
 import qualified System.Random.MWC as MWC
 
@@ -17,17 +17,14 @@ import NestedSampling.Utils
 
 type Particle = U.Vector Double
 
--- A sampler
-data Sampler = Sampler
-               {
-                   numParticles      :: {-# UNPACK #-} !Int,
-                   mcmcSteps         :: {-# UNPACK #-} !Int,
-                   theParticles      :: !(V.Vector Particle),
-                   theLogLikelihoods :: !Particle,
-                   iteration         :: {-# UNPACK #-} !Int,
-                   logZ              :: {-# UNPACK #-} !Double,
-                   information       :: {-# UNPACK #-} !Double
-               } deriving Show
+data Sampler = Sampler {
+    numParticles      :: {-# UNPACK #-} !Int
+  , mcmcSteps         :: {-# UNPACK #-} !Int
+  , theParticles      :: !(IntPSQ Double Particle) -- Particles weighted by loglikelihoods
+  , iteration         :: {-# UNPACK #-} !Int
+  , logZ              :: {-# UNPACK #-} !Double
+  , information       :: {-# UNPACK #-} !Double
+  } deriving Show
 
 -- | Choose a particle to copy, that isn't number k.
 chooseCopy :: Int -> Int -> Gen RealWorld -> IO Int
@@ -42,14 +39,13 @@ chooseCopy k n = loop where
 generateSampler :: Int -> Int -> Gen RealWorld -> IO Sampler
 generateSampler n m gen = do
     putStrLn $ "Generating " ++ show nv ++ " particles from the prior..."
-    particles <- V.replicateM nv (fromPrior gen)
-    let lls = V.map logLikelihood particles
+    particles <- replicateM nv (fromPrior gen)
+    let lls = fmap logLikelihood particles
     putStrLn "done."
     return Sampler {
         numParticles      = nv
       , mcmcSteps         = mv
-      , theParticles      = particles
-      , theLogLikelihoods = U.convert lls
+      , theParticles      = PSQ.fromList (zip3 [0..] lls particles)
       , iteration         = 1
       , logZ              = -1E300
       , information       = 0.0
@@ -59,15 +55,12 @@ generateSampler n m gen = do
     mv = if m <= 0 then 0 else m
 
 -- Find the index and the log likelihood value of the worst particle
---
--- NB (jtobin):
---   It may be better to use something like a heap so that we can access the
---   min element in O(1).
-findWorstParticle :: Sampler -> (Int, Double)
-findWorstParticle sampler = (idx, U.unsafeIndex lls idx)
-    where
-        idx = U.minIndex lls
-        lls = theLogLikelihoods sampler
+findWorstParticle :: Sampler -> (Int, Double, Particle)
+findWorstParticle sampler = case worst of
+    Just (idx, ll, p) -> (idx, ll, p)
+    Nothing           -> error "findWorstParticle: no particles found"
+  where
+    worst = PSQ.findMin (theParticles sampler)
 
 -- Function to do a single metropolis update
 -- Input: A vector of parameters and a loglikelihood threshold
@@ -97,14 +90,14 @@ metropolisUpdates = loop where
                     loop (n-1) threshold next gen
 {-# INLINE metropolisUpdates #-}
 
--- Do many NestedSampling iterations
+-- -- Do many NestedSampling iterations
 nestedSamplingIterations :: Int -> Sampler -> Gen RealWorld -> IO Sampler
 nestedSamplingIterations = loop where
   loop n sampler gen
     | n <= 0    = return sampler
     | otherwise = do
-                    next <- nestedSamplingIteration sampler gen
-                    loop (n-1) next gen
+        next <- nestedSamplingIteration sampler gen
+        loop (n-1) next gen
 {-# INLINE nestedSamplingIterations #-}
 
 -- Save a particle to disk
@@ -128,75 +121,63 @@ writeToFile append (logw, logl) particle = do
 -- Do a single NestedSampling iteration
 nestedSamplingIteration :: Sampler -> Gen RealWorld -> IO Sampler
 nestedSamplingIteration sampler gen = do
-    let it = iteration sampler
-    let logX = negate $ (fromIntegral it) / (fromIntegral (numParticles sampler)) :: Double
-    let worst = findWorstParticle sampler
+  let it   = iteration sampler
+      n    = numParticles sampler
+      logX = negate $ (fromIntegral it) / (fromIntegral (numParticles sampler))
 
-    let iWorst = fst worst
-    let n = numParticles sampler
-    copy <- chooseCopy iWorst n gen
+      (iWorst, logLike, worst) = findWorstParticle sampler
+      particles                = theParticles sampler
 
-    -- Approximate log prior weight of the worst particle
-    let logPriorWeight = -(k/np) + log (exp (1.0/np) - 1.0) where
-          k  = fromIntegral it
-          np = fromIntegral (numParticles sampler)
-    let logPost = logPriorWeight + logLike where
-          logLike = snd worst
-    let logZ' = logsumexp (logZ sampler) logPost
+  copy <- chooseCopy iWorst n gen
 
-    let information' = exp (logPost - logZ') * (snd worst)
-                       + exp (logZ sampler - logZ') *
-                          (information sampler + logZ sampler) - logZ'
+  -- Approximate log prior weight of the worst particle
+  let logPriorWeight = -(k/np) + log (exp (1.0/np) - 1.0) where
+        k  = fromIntegral it
+        np = fromIntegral (numParticles sampler)
 
-    --H = exp(Obj[worst].logWt - logZnew) * Obj[worst].logL
-    -- + exp(logZ - logZnew) * (H + logZ) - logZnew;
-    --logZ = logZnew;
+  let logPost = logPriorWeight + logLike
 
-    -- Print some stuff from time to time
-    let display = it `mod` (numParticles sampler) == 0 :: Bool
-    if display then do
-        putStr   $ "Iteration " ++ (show it) ++ ". "
-        putStr   $ "ln(X) = " ++ (show logX) ++ ". "
-        putStrLn $ "ln(L) = " ++ (show $ snd worst) ++ "."
-        putStr   $ "ln(Z) = " ++ (show logZ') ++ ", "
-        putStrLn $ "H = " ++ (show information') ++ " nats.\n"
+  let logZ' = logsumexp (logZ sampler) logPost
 
-    else return ()
---        putStr $ "log(L) = " ++ (show $ snd worst) ++ ". " }
---        when (it == 1)
+  let information' = exp (logPost - logZ') * logLike
+                     + exp (logZ sampler - logZ') *
+                        (information sampler + logZ sampler) - logZ'
 
+  -- Print some stuff from time to time
+  let display = it `mod` (numParticles sampler) == 0 :: Bool
+  when display $ do
+    putStr   $ "Iteration " ++ (show it) ++ ". "
+    putStr   $ "ln(X) = " ++ (show logX) ++ ". "
+    putStrLn $ "ln(L) = " ++ (show logLike) ++ "."
+    putStr   $ "ln(Z) = " ++ (show logZ') ++ ", "
+    putStrLn $ "H = " ++ (show information') ++ " nats.\n"
 
-    -- Write to file
-    writeToFile (it /= 1) (logPriorWeight, snd worst)
-                        $ (theParticles sampler) V.! iWorst
+  -- Write to file
+  writeToFile (it /= 1) (logPriorWeight, logLike) worst
 
+  let particle = case PSQ.lookup copy particles of
+        Nothing      -> error "nestedSamplingIteration: no particles found"
+        Just (ll, p) -> (p, ll)
 
-    -- Copy a surviving particle
-    let particle = (V.unsafeIndex (theParticles sampler) copy,
-                        U.unsafeIndex (theLogLikelihoods sampler) copy)
+  -- Do Metropolis
+  let update = metropolisUpdates (mcmcSteps sampler) logLike
+  (newParticle, newLoglikelihood) <- update particle gen
 
-    -- Do Metropolis
-    let update = metropolisUpdates (mcmcSteps sampler) (snd worst)
-    newParticle <- update particle gen
+  let substituteNew mparticle = case mparticle of
+        Just (idx, _, _) -> ((), Just (idx, newLoglikelihood, newParticle))
+        Nothing          -> ((), Nothing)
 
-    theParticles' <- do
-      mvec <- V.unsafeThaw (theParticles sampler)
-      VM.unsafeModify mvec (const (fst newParticle)) iWorst
-      V.unsafeFreeze mvec
+  let (_, theParticles') = PSQ.alterMin substituteNew particles
 
-    theLogLikelihoods' <- do
-      mvec <- U.unsafeThaw (theLogLikelihoods sampler)
-      UM.unsafeModify mvec (const (snd newParticle)) iWorst
-      U.unsafeFreeze mvec
+  -- Updated sampler
+  let sampler' = Sampler {
+          numParticles      = numParticles sampler
+        , mcmcSteps         = mcmcSteps sampler
+        , theParticles      = theParticles'
+        , iteration         = it + 1
+        , logZ              = logZ'
+        , information       = information'
+        }
 
-    -- Updated sampler
-    let !sampler' = Sampler { numParticles=(numParticles sampler),
-                     mcmcSteps=(mcmcSteps sampler),
-                     theParticles=theParticles',
-                     theLogLikelihoods=theLogLikelihoods',
-                     iteration=(it + 1),
-                     logZ=logZ',
-                     information=information'}
-
-    return $! sampler'
+  return $! sampler'
 

--- a/lib/NestedSampling/SpikeSlab.hs
+++ b/lib/NestedSampling/SpikeSlab.hs
@@ -1,7 +1,7 @@
 module NestedSampling.SpikeSlab where
 
 import Control.Monad.Primitive (RealWorld)
-import Data.Vector.Unboxed as U
+import qualified Data.Vector.Unboxed as U
 import qualified Data.Vector.Unboxed.Mutable as UM
 import NestedSampling.Utils
 import System.Random.MWC (Gen, uniform, uniformR)
@@ -26,8 +26,8 @@ logLikelihood params = logsumexp (logl1 + log 100.0) logl2
 -- representing a point in the parameter space
 fromPrior :: Gen RealWorld -> IO (U.Vector Double)
 fromPrior gen = do
-    x <- U.replicateM 20 (uniform gen)
-    return $ U.map (\a -> a - 0.5) x
+  x <- U.replicateM 20 (uniform gen)
+  return $ U.map (subtract 0.5) x
 
 -- Perturb takes a list of doubles as input
 -- and returns an IO action that returns the

--- a/src/Mini.hs
+++ b/src/Mini.hs
@@ -1,0 +1,11 @@
+import NestedSampling.Sampler
+import System.Random.MWC
+
+main :: IO ()
+main = withSystemRandom . asGenIO $ \gen -> do
+  sampler <- generateSampler 1000 1000 gen
+
+  _ <- nestedSamplingIterations 1000 sampler gen
+
+  return ()
+


### PR DESCRIPTION
I mentioned that I tried a PSQ implementation to see if we could get any performance boosts from O(1) access to the worst particle.  It looks like the tradeoff in terms of performance is just about equal - we get constant-time access to the worst particle, but have to use a boxed representation for the log-likelihoods.

Here's the profiling summary for the vector implementation:

	Sat Dec  3 14:27 2016 Time and Allocation Profiling Report  (Final)

	   ns-mini-example +RTS -s -p -RTS

	total time  =       40.57 secs   (40572 ticks @ 1000 us, 1 processor)
	total alloc = 27,329,352,968 bytes  (excludes profiling overheads)

And here it is for the PSQ implementation:

	Sat Dec  3 14:20 2016 Time and Allocation Profiling Report  (Final)

	   ns-mini-example +RTS -s -p -RTS

	total time  =       40.94 secs   (40936 ticks @ 1000 us, 1 processor)
	total alloc = 27,082,342,552 bytes  (excludes profiling overheads)

The PSQ implementation allocates less, but just barely.  They're pretty much indistinguishable.

The PSQ API is really nice though and I think makes things easier to work with.  Rather than doing manual index arithmetic to get at the worst particle, we can always just do it via the supplied `findMin` function from `psqueues`.  And we can keep the particles and their log-likelihoods in the same place, which is actually super nice.

So, I'm inclined to keep it.  Yeah bru / nah bru?
