### PR TITLE
Add quiet logging options.

### DIFF
--- a/NestedSampling-hs.cabal
+++ b/NestedSampling-hs.cabal
@@ -1,5 +1,5 @@
 name:                NestedSampling-hs
-version:             0.3.1
+version:             0.3.2
 synopsis:            Classic Nested Sampling.
 license:             MIT
 license-file:        LICENSE

--- a/lib/NestedSampling/Sampler.hs
+++ b/lib/NestedSampling/Sampler.hs
@@ -16,6 +16,7 @@ module NestedSampling.Sampler (
     -- * logging
   , LoggingOptions(..)
   , defaultLogging
+  , noLogging
   ) where
 
 import Control.Monad
@@ -95,15 +96,19 @@ data LoggingOptions = LoggingOptions {
   , logProgress       :: Bool
   }
 
--- NB (jtobin):
---   Possibly best to use 'Nothing' as default values for sampler/particle
---   information and let users overwrite these if desired.
-
 -- | Default logging options for samplers.
 defaultLogging :: LoggingOptions
 defaultLogging = LoggingOptions {
     logSamplerFile    = Just "nested_sampling_info.csv"
   , logParametersFile = Just "nested_sampling_parameters.csv"
+  , logProgress       = True
+  }
+
+-- | Quiet (stdout-only) logging options for samplers.
+noLogging :: LoggingOptions
+noLogging = LoggingOptions {
+    logSamplerFile    = Nothing
+  , logParametersFile = Nothing
   , logProgress       = True
   }
 

--- a/test/Mini.hs
+++ b/test/Mini.hs
@@ -8,7 +8,7 @@ main = withSystemRandom . asGenIO $ \gen -> do
     origin <- initialize 1000 100 fromPrior logLikelihood perturb gen
 
     -- Do 100000 NS iterations (this'll go to a depth of 100 nats)
-    _ <- nestedSampling defaultLogging 1000 origin gen
+    _ <- nestedSampling noLogging 1000 origin gen
 
     return ()
 


### PR DESCRIPTION
In addition to 'defaultLogging' we can also export 'noLogging' here that doesn't write to disk.

I've used it in the mini spike/slab example as I pretty much just run that thing to get an idea of whether or not I've broken something. 😄 